### PR TITLE
Allow to connect to Azure Storage Queues and Azure Service Bus with Managed Identity

### DIFF
--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureMessageQueueOptions.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureMessageQueueOptions.cs
@@ -5,8 +5,21 @@ namespace OneBeyond.Studio.Infrastructure.Azure.MessageQueues.Options;
 
 public record AzureMessageQueueOptions
 {
+    /// <summary>
+    /// The name of the Azure resource to use for Azure Identity authentication.
+    /// NOTE: If specified, a connection string must not be provided.
+    /// </summary>
     public string? ResourceName { get; init; }
+
+    /// <summary>
+    /// The connection string to use for authentication.
+    /// NOTE: if specified, a resource name must not be provided.
+    /// </summary>
     public string? ConnectionString { get; init; }
+
+    /// <summary>
+    /// The name of the queue to use.
+    /// </summary>
     public string? QueueName { get; init; }
 
     public virtual void EnsureIsValid()
@@ -14,13 +27,13 @@ public record AzureMessageQueueOptions
         if (ConnectionString.IsNullOrWhiteSpace() && ResourceName.IsNullOrWhiteSpace())
         {
             throw new ArgumentException("At least one connection must be provided, " +
-                "either the connection string or the resource name (for Managed Identity usage).");
+                "either the connection string or the resource name (for Azure Identity usage).");
         }
 
         if (!ConnectionString.IsNullOrWhiteSpace() && !ResourceName.IsNullOrWhiteSpace())
         {
             throw new ArgumentException("Only one connection can be provided, " +
-                "either the connection string or the resource name (for Managed Identity usage).");
+                "either the connection string or the resource name (for Azure Identity usage).");
         }
 
         if (QueueName.IsNullOrWhiteSpace())

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureMessageQueueOptions.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureMessageQueueOptions.cs
@@ -13,13 +13,13 @@ public record AzureMessageQueueOptions
     {
         if (ConnectionString.IsNullOrWhiteSpace() && ResourceName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(ConnectionString), "At least one connection must be provided, " +
+            throw new ArgumentException("At least one connection must be provided, " +
                 "either the connection string or the resource name (for Managed Identity usage).");
         }
 
         if (!ConnectionString.IsNullOrWhiteSpace() && !ResourceName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(ConnectionString), "Only one connection can be provided, " +
+            throw new ArgumentException("Only one connection can be provided, " +
                 "either the connection string or the resource name (for Managed Identity usage).");
         }
 

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureMessageQueueOptions.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureMessageQueueOptions.cs
@@ -5,19 +5,27 @@ namespace OneBeyond.Studio.Infrastructure.Azure.MessageQueues.Options;
 
 public record AzureMessageQueueOptions
 {
+    public string? ResourceName { get; init; }
     public string? ConnectionString { get; init; }
     public string? QueueName { get; init; }
 
     public virtual void EnsureIsValid()
     {
-        if (ConnectionString.IsNullOrWhiteSpace())
+        if (ConnectionString.IsNullOrWhiteSpace() && ResourceName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(ConnectionString), "Azure message queue connection string is null.");
+            throw new ArgumentNullException(nameof(ConnectionString), "At least one connection must be provided, " +
+                "either the connection string or the resource name (for Managed Identity usage).");
+        }
+
+        if (!ConnectionString.IsNullOrWhiteSpace() && !ResourceName.IsNullOrWhiteSpace())
+        {
+            throw new ArgumentNullException(nameof(ConnectionString), "Only one connection can be provided, " +
+                "either the connection string or the resource name (for Managed Identity usage).");
         }
 
         if (QueueName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(QueueName), "Azure message queue name is null.");
+            throw new ArgumentNullException(nameof(QueueName), "The Azure message queue name has not been provided.");
         }
     }
 }

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureServicePubSubBusMessageQueueOptions.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureServicePubSubBusMessageQueueOptions.cs
@@ -5,8 +5,21 @@ namespace OneBeyond.Studio.Infrastructure.Azure.MessageQueues.Options;
 
 public record AzureServicePubSubBusMessageQueueOptions
 {
+    /// <summary>
+    /// The name of the Azure resource to use for Azure Identity authentication.
+    /// NOTE: If specified, a connection string must not be provided.
+    /// </summary>
     public string? ResourceName { get; init; }
+
+    /// <summary>
+    /// The connection string to use for authentication.
+    /// NOTE: if specified, a resource name must not be provided.
+    /// </summary>
     public string? ConnectionString { get; init; }
+
+    /// <summary>
+    /// The name of the topic to use.
+    /// </summary>
     public string? TopicName { get; init; }
 
     public virtual void EnsureIsValid()
@@ -14,13 +27,13 @@ public record AzureServicePubSubBusMessageQueueOptions
         if (ConnectionString.IsNullOrWhiteSpace() && ResourceName.IsNullOrWhiteSpace())
         {
             throw new ArgumentException("At least one connection must be provided, " +
-                "either the connection string or the namespace name (for Managed Identity usage).");
+                "either the connection string or the namespace name (for Azure Identity usage).");
         }
 
         if (!ConnectionString.IsNullOrWhiteSpace() && !ResourceName.IsNullOrWhiteSpace())
         {
             throw new ArgumentException("Only one connection can be provided, " +
-                "either the connection string or the namespace name (for Managed Identity usage).");
+                "either the connection string or the namespace name (for Azure Identity usage).");
         }
 
         if (TopicName.IsNullOrWhiteSpace())

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureServicePubSubBusMessageQueueOptions.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureServicePubSubBusMessageQueueOptions.cs
@@ -13,13 +13,13 @@ public record AzureServicePubSubBusMessageQueueOptions
     {
         if (ConnectionString.IsNullOrWhiteSpace() && ResourceName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(ConnectionString), "At least one connection must be provided, " +
+            throw new ArgumentException("At least one connection must be provided, " +
                 "either the connection string or the namespace name (for Managed Identity usage).");
         }
 
         if (!ConnectionString.IsNullOrWhiteSpace() && !ResourceName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(ConnectionString), "Only one connection can be provided, " +
+            throw new ArgumentException("Only one connection can be provided, " +
                 "either the connection string or the namespace name (for Managed Identity usage).");
         }
 

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureServicePubSubBusMessageQueueOptions.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/Options/AzureServicePubSubBusMessageQueueOptions.cs
@@ -5,19 +5,27 @@ namespace OneBeyond.Studio.Infrastructure.Azure.MessageQueues.Options;
 
 public record AzureServicePubSubBusMessageQueueOptions
 {
+    public string? ResourceName { get; init; }
     public string? ConnectionString { get; init; }
     public string? TopicName { get; init; }
 
     public virtual void EnsureIsValid()
     {
-        if (ConnectionString.IsNullOrWhiteSpace())
+        if (ConnectionString.IsNullOrWhiteSpace() && ResourceName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(ConnectionString), "Azure topic connection string is null.");
+            throw new ArgumentNullException(nameof(ConnectionString), "At least one connection must be provided, " +
+                "either the connection string or the namespace name (for Managed Identity usage).");
+        }
+
+        if (!ConnectionString.IsNullOrWhiteSpace() && !ResourceName.IsNullOrWhiteSpace())
+        {
+            throw new ArgumentNullException(nameof(ConnectionString), "Only one connection can be provided, " +
+                "either the connection string or the namespace name (for Managed Identity usage).");
         }
 
         if (TopicName.IsNullOrWhiteSpace())
         {
-            throw new ArgumentNullException(nameof(TopicName), "Azure topic name is null.");
+            throw new ArgumentNullException(nameof(TopicName), "The Azure topic name has not been provided.");
         }
     }
 }

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/ServiceBusMessageQueueBase.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/ServiceBusMessageQueueBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using EnsureThat;
@@ -26,7 +27,10 @@ internal abstract class ServiceBusMessageQueueBase<TMessage>
             async () =>
             {
                 var requiresSession = !options.SessionId.IsNullOrWhiteSpace();
-                var serviceBusAdminClient = new ServiceBusAdministrationClient(options.ConnectionString);
+                var serviceBusAdminClient = string.IsNullOrWhiteSpace(options.ResourceName)
+                    ? new ServiceBusAdministrationClient(options.ConnectionString)
+                    : new ServiceBusAdministrationClient($"{options.ResourceName}.servicebus.windows.net", new DefaultAzureCredential());
+                
                 var queueExists = await serviceBusAdminClient.QueueExistsAsync(
                         options.QueueName)
                     .ConfigureAwait(false);

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/ServiceBusMessageQueueReceiver.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/ServiceBusMessageQueueReceiver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using EnsureThat;
@@ -31,7 +32,10 @@ internal sealed class ServiceBusMessageQueueReceiver<TMessage>
         _ensureQueueExists = new AsyncLazy<bool>(
             async () =>
             {
-                var serviceBusAdminClient = new ServiceBusAdministrationClient(options.ConnectionString);
+                var serviceBusAdminClient = string.IsNullOrWhiteSpace(options.ResourceName)
+                    ? new ServiceBusAdministrationClient(options.ConnectionString)
+                    : new ServiceBusAdministrationClient($"{options.ResourceName}.servicebus.windows.net", new DefaultAzureCredential());
+
                 var queueExists = await serviceBusAdminClient.QueueExistsAsync(
                         options.QueueName)
                     .ConfigureAwait(false);

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/ServiceBusPubSubMessageQueueBase.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/ServiceBusPubSubMessageQueueBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using EnsureThat;
@@ -25,7 +26,10 @@ internal abstract class ServiceBusPubSubMessageQueueBase<TMessage>
         _ensureTopicExists = new AsyncLazy<bool>(
             async () =>
             {
-                var serviceBusAdminClient = new ServiceBusAdministrationClient(options.ConnectionString);
+                var serviceBusAdminClient = string.IsNullOrWhiteSpace(options.ResourceName)
+                    ? new ServiceBusAdministrationClient(options.ConnectionString)
+                    : new ServiceBusAdministrationClient($"{options.ResourceName}.servicebus.windows.net", new DefaultAzureCredential());
+
                 var queueExists = await serviceBusAdminClient.TopicExistsAsync(
                         options.TopicName)
                     .ConfigureAwait(false);

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageLargeMessageQueueBase.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageLargeMessageQueueBase.cs
@@ -26,11 +26,11 @@ internal abstract class StorageLargeMessageQueueBase<TMessage> : IMessageQueue<T
         options.EnsureIsValid();
 
         _messageBlobContainer = new AsyncLazy<BlobContainerClient>(
-            () => BlobContainer.GetOrCreateAsync(options.ConnectionString!, options.ContainerName!),
+            () => BlobContainer.GetOrCreateAsync(options.ResourceName, options.ConnectionString!, options.ContainerName!),
             AsyncLazyFlags.RetryOnFailure);
 
         _messageQueue = new AsyncLazy<QueueClient>(
-            () => Queue.GetOrCreateAsync(options.ConnectionString!, options.QueueName!),
+            () => Queue.GetOrCreateAsync(options.ResourceName, options.ConnectionString!, options.QueueName!),
             AsyncLazyFlags.RetryOnFailure);
     }
 

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageLargeMessageQueueBase.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageLargeMessageQueueBase.cs
@@ -26,11 +26,11 @@ internal abstract class StorageLargeMessageQueueBase<TMessage> : IMessageQueue<T
         options.EnsureIsValid();
 
         _messageBlobContainer = new AsyncLazy<BlobContainerClient>(
-            () => BlobContainer.GetOrCreateAsync(options.ResourceName, options.ConnectionString!, options.ContainerName!),
+            () => BlobContainer.GetOrCreateAsync(options.ResourceName, options.ConnectionString, options.ContainerName!),
             AsyncLazyFlags.RetryOnFailure);
 
         _messageQueue = new AsyncLazy<QueueClient>(
-            () => Queue.GetOrCreateAsync(options.ResourceName, options.ConnectionString!, options.QueueName!),
+            () => Queue.GetOrCreateAsync(options.ResourceName, options.ConnectionString, options.QueueName!),
             AsyncLazyFlags.RetryOnFailure);
     }
 

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageMessageQueueBase.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageMessageQueueBase.cs
@@ -22,7 +22,7 @@ internal abstract class StorageMessageQueueBase<TMessage> : IMessageQueue<TMessa
         options.EnsureIsValid();
 
         _messageQueue = new AsyncLazy<QueueClient>(
-            () => Queue.GetOrCreateAsync(options.ConnectionString!, options.QueueName!), //We ensured both ConnectionString and QueueName are specified above
+            () => Queue.GetOrCreateAsync(options.ResourceName, options.ConnectionString!, options.QueueName!),
             AsyncLazyFlags.RetryOnFailure);
     }
 

--- a/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageMessageQueueBase.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/MessageQueues/StorageMessageQueueBase.cs
@@ -22,7 +22,7 @@ internal abstract class StorageMessageQueueBase<TMessage> : IMessageQueue<TMessa
         options.EnsureIsValid();
 
         _messageQueue = new AsyncLazy<QueueClient>(
-            () => Queue.GetOrCreateAsync(options.ResourceName, options.ConnectionString!, options.QueueName!),
+            () => Queue.GetOrCreateAsync(options.ResourceName, options.ConnectionString, options.QueueName!),
             AsyncLazyFlags.RetryOnFailure);
     }
 

--- a/src/OneBeyond.Studio.Infrastructure.Azure/Storage/BlobContainer.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/Storage/BlobContainer.cs
@@ -17,7 +17,7 @@ public static class BlobContainer
     {
         return string.IsNullOrWhiteSpace(storageName)
             ? await GetOrCreateConnectionStringAsync(connectionString!, queueName, cancellationToken).ConfigureAwait(false)
-            : await GetOrCreateManagedIdentityAsync(storageName!, queueName, cancellationToken).ConfigureAwait(false);
+            : await GetOrCreateAzureIdentityAsync(storageName!, queueName, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<BlobContainerClient> GetOrCreateConnectionStringAsync(
@@ -35,7 +35,7 @@ public static class BlobContainer
         return blobContainerClient;
     }
 
-    private static async Task<BlobContainerClient> GetOrCreateManagedIdentityAsync(
+    private static async Task<BlobContainerClient> GetOrCreateAzureIdentityAsync(
        string storageName,
        string containerName,
        CancellationToken cancellationToken = default)

--- a/src/OneBeyond.Studio.Infrastructure.Azure/Storage/BlobContainer.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/Storage/BlobContainer.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using EnsureThat;
 
@@ -8,6 +10,17 @@ namespace OneBeyond.Studio.Infrastructure.Azure.Storage;
 public static class BlobContainer
 {
     public static async Task<BlobContainerClient> GetOrCreateAsync(
+        string? storageName,
+        string? connectionString,
+        string queueName,
+        CancellationToken cancellationToken = default)
+    {
+        return string.IsNullOrWhiteSpace(storageName)
+            ? await GetOrCreateConnectionStringAsync(connectionString!, queueName, cancellationToken).ConfigureAwait(false)
+            : await GetOrCreateManagedIdentityAsync(storageName!, queueName, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<BlobContainerClient> GetOrCreateConnectionStringAsync(
         string connectionString,
         string containerName,
         CancellationToken cancellationToken = default)
@@ -16,6 +29,23 @@ public static class BlobContainer
         EnsureArg.IsNotNullOrWhiteSpace(containerName, nameof(containerName));
 
         var blobContainerClient = new BlobContainerClient(connectionString, containerName);
+
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return blobContainerClient;
+    }
+
+    private static async Task<BlobContainerClient> GetOrCreateManagedIdentityAsync(
+       string storageName,
+       string containerName,
+       CancellationToken cancellationToken = default)
+    {
+        EnsureArg.IsNotNullOrWhiteSpace(storageName, nameof(storageName));
+        EnsureArg.IsNotNullOrWhiteSpace(containerName, nameof(containerName));
+
+        var blobContainerClient = new BlobContainerClient(
+           new Uri($"https://{storageName}.blob.core.windows.net/{containerName}"),
+           new DefaultAzureCredential());
 
         await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/src/OneBeyond.Studio.Infrastructure.Azure/Storage/Queue.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/Storage/Queue.cs
@@ -17,7 +17,7 @@ public static class Queue
     {
         return string.IsNullOrWhiteSpace(storageName)
             ? await GetOrCreateConnectionStringAsync(connectionString!, queueName, cancellationToken).ConfigureAwait(false)
-            : await GetOrCreateManagedIdentityAsync(storageName!, queueName, cancellationToken).ConfigureAwait(false);
+            : await GetOrCreateAzureIdentityAsync(storageName!, queueName, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<QueueClient> GetOrCreateConnectionStringAsync(
@@ -35,7 +35,7 @@ public static class Queue
         return queueClient;
     }
 
-    private static async Task<QueueClient> GetOrCreateManagedIdentityAsync(
+    private static async Task<QueueClient> GetOrCreateAzureIdentityAsync(
         string storageName,
         string queueName,
         CancellationToken cancellationToken = default)

--- a/src/OneBeyond.Studio.Infrastructure.Azure/Storage/Queue.cs
+++ b/src/OneBeyond.Studio.Infrastructure.Azure/Storage/Queue.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Azure.Storage.Queues;
 using EnsureThat;
 
@@ -8,6 +10,17 @@ namespace OneBeyond.Studio.Infrastructure.Azure.Storage;
 public static class Queue
 {
     public static async Task<QueueClient> GetOrCreateAsync(
+        string? storageName,
+        string? connectionString,
+        string queueName,
+        CancellationToken cancellationToken = default)
+    {
+        return string.IsNullOrWhiteSpace(storageName)
+            ? await GetOrCreateConnectionStringAsync(connectionString!, queueName, cancellationToken).ConfigureAwait(false)
+            : await GetOrCreateManagedIdentityAsync(storageName!, queueName, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<QueueClient> GetOrCreateConnectionStringAsync(
         string connectionString,
         string queueName,
         CancellationToken cancellationToken = default)
@@ -16,6 +29,23 @@ public static class Queue
         EnsureArg.IsNotNullOrWhiteSpace(queueName, nameof(queueName));
 
         var queueClient = new QueueClient(connectionString, queueName);
+
+        await queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return queueClient;
+    }
+
+    private static async Task<QueueClient> GetOrCreateManagedIdentityAsync(
+        string storageName,
+        string queueName,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureArg.IsNotNullOrWhiteSpace(storageName, nameof(storageName));
+        EnsureArg.IsNotNullOrWhiteSpace(queueName, nameof(queueName));
+
+        var queueClient = new QueueClient(
+            new Uri($"https://{storageName}.queue.core.windows.net/{queueName}"), 
+            new DefaultAzureCredential());
 
         await queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
## Description
With the current change, the following resources can now be used with Managed Identity rather than a connection string:
- Azure Storage Queues
- Azure Storage Containers
- Azure Service Bus

It's now possible to specify the `ResourceName` to connect to, provided that a Managed Identity has been set.

## Motivation and Context
Flexibility of usage