### PR TITLE
Allow AuthorizationRequirements to work also with commands returning void

### DIFF
--- a/src/OneBeyond.Studio.Application.SharedKernel/Authorization/AuthorizationRequirementBehavior.cs
+++ b/src/OneBeyond.Studio.Application.SharedKernel/Authorization/AuthorizationRequirementBehavior.cs
@@ -18,7 +18,7 @@ namespace OneBeyond.Studio.Application.SharedKernel.Authorization;
 public class AuthorizationRequirementBehavior<TRequest, TResponse>
     : AuthorizationRequirementBehavior
     , IPipelineBehavior<TRequest, TResponse>
-    where TRequest : class, IRequest<TResponse>
+    where TRequest : class, IBaseRequest
 {
     private readonly ILifetimeScope _container;
     private readonly AuthorizationOptions _authorizationOptions;


### PR DESCRIPTION
## Description
Allow AuthorizationRequirements to work also with commands returning void

## Motivation and Context
Allow to use AuthorizationPolicy attributes also against Mediatr commands implementing IRequest without a TResponse.
