### PR TITLE
Update file validators to handle mp3 and rtf formats

### DIFF
--- a/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/FileSignatureValidator.cs
+++ b/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/FileSignatureValidator.cs
@@ -86,7 +86,10 @@ public abstract class FileSignatureValidator : IFileContentValidator
         ValidateFileContent(
             fileName,
             contentType,
-            (sizeToRead) => new ReadOnlySpan<byte>(content, 0, sizeToRead).ToArray());
+            (sizeToRead) => new ReadOnlySpan<byte>(content, 0, sizeToRead > content.Length 
+                ? content.Length
+                : sizeToRead
+                ).ToArray());
     }
 
     /// <summary>

--- a/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/FileValidatorBuilder.cs
+++ b/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/FileValidatorBuilder.cs
@@ -74,7 +74,8 @@ public sealed class FileValidatorBuilder
             .AddValidator(new MpegValidator());
 
     public FileValidatorBuilder AllowAudio()
-        => AddValidator(new WavValidator());
+        => AddValidator(new WavValidator())
+            .AddValidator(new Mp3Validator());
 
     public FileValidatorBuilder AllowVisio()
         => AddValidator(new VisioValidator());

--- a/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/OfficeValidators/WordValidator.cs
+++ b/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/OfficeValidators/WordValidator.cs
@@ -9,8 +9,13 @@ public sealed class WordValidator : FileSignatureValidator
     public WordValidator()
         : base(
               "application/msword",
-              new[] { ".doc" },
-              "D0-CF-11-E0-A1-B1-1A-E1")
+              new[] { ".doc", ".rtf" },
+              new[] {
+                  "D0-CF-11-E0-A1-B1-1A-E1",
+                  // rtf will have different signatures depending on which program created them
+                  "50-4B-03-04-14",
+                  "7B-5C-72-74-66"
+              })
     {
     }
 }

--- a/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/OtherValidators/Mp3Validator.cs
+++ b/src/OneBeyond.Studio.Crosscuts/Utilities/FileUploadValidators/OtherValidators/Mp3Validator.cs
@@ -1,0 +1,17 @@
+namespace OneBeyond.Studio.Crosscuts.Utilities.FileUploadValidators.OtherValidators;
+
+public sealed class Mp3Validator : FileSignatureValidator
+{
+    public Mp3Validator()
+        : base(
+            "audio/mpeg",
+            new[] { ".mp3" },
+            new[]
+            {
+                "FF-FB",
+                "49-44-33",
+                "FF-F2"
+            })
+    {
+    }
+}


### PR DESCRIPTION
Add mp3 and rtf support
Handle case where very small files causes an exception to be thrown on validation


## Related Issue
https://github.com/onebeyond/onebeyond-studio-core/issues/122

## Motivation and Context
Expanded support for file validation

## How Has This Been Tested?
This was tested on a dev laptop
obelisk was built locally
a working project was updated to use the local version of Obelisk as a project dependency 
The code was stepped through and tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
