### PR TITLE
[FIX] Support polymorphic projections

### DIFF
--- a/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.TestModels.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.TestModels.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using OneBeyond.Studio.Domain.SharedKernel.Entities;
+
+namespace OneBeyond.Studio.DataAccess.EFCore.Tests.Projections;
+
+public sealed partial class EntityTypeProjectionsTests
+{
+    internal abstract class Animal : DomainEntity<Guid>
+    {
+        protected Animal() : base(Guid.CreateVersion7()) { }
+    }
+
+    internal class Dog : Animal;
+
+    [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Mock type for testing.")]
+    internal sealed class Husky : Dog;
+
+
+    internal sealed record DogDto
+    {
+        public required string Id { get; init; }
+    }
+
+    internal sealed record DogSummaryDto
+    {
+        public required string Name { get; init; }
+    }
+}

--- a/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.cs
@@ -1,67 +1,167 @@
-using System.Reflection;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using OneBeyond.Studio.DataAccess.EFCore.Projections;
 
 namespace OneBeyond.Studio.DataAccess.EFCore.Tests.Projections;
 
 [TestClass]
-public sealed class EntityTypeProjectionsTests
+public sealed partial class EntityTypeProjectionsTests
 {
-    private readonly Mock<IEntityTypeProjection<SomeEntity, SomeDto1>> _dto1ProjectionMock;
-    private readonly Mock<IEntityTypeProjection<SomeEntity, SomeDto2>> _dto2ProjectionMock;
-    private readonly Mock<IEntityTypeProjection> _incompleteProjectionMock;
+    private readonly DbContext _dbContextMock = Mock.Of<DbContext>();
 
-    public EntityTypeProjectionsTests()
+    internal sealed class DogProjection : IEntityTypeProjection<Dog, DogDto>
     {
-        _dto1ProjectionMock = new Mock<IEntityTypeProjection<SomeEntity, SomeDto1>>();
-        _dto2ProjectionMock = _dto1ProjectionMock.As<IEntityTypeProjection<SomeEntity, SomeDto2>>();
-        _incompleteProjectionMock = new Mock<IEntityTypeProjection>();
+        public IQueryable<DogDto> Project(IQueryable<Dog> entityQuery, ProjectionContext context)
+            => entityQuery.Select(dog => new DogDto { Id = $"DogDto-{dog.IdAsString}" });
+    }
 
+    internal sealed class DogMultiProjection : IEntityTypeProjection<Dog, DogDto>, IEntityTypeProjection<Dog, DogSummaryDto>
+    {
+        IQueryable<DogDto> IEntityTypeProjection<Dog, DogDto>.Project(IQueryable<Dog> entityQuery, ProjectionContext context)
+            => entityQuery.Select(dog => new DogDto { Id = $"DogDto-{dog.IdAsString}" });
+
+        IQueryable<DogSummaryDto> IEntityTypeProjection<Dog, DogSummaryDto>.Project(IQueryable<Dog> entityQuery, ProjectionContext context)
+            => entityQuery.Select(dog => new DogSummaryDto { Name = $"DogSummary-{dog.IdAsString}" });
+    }
+
+
+    [TestMethod]
+    public void Ctor_GenericInterfaceNotImplemented_ArgumentOutOfRangeException()
+    {
+        // Arrange
+        var incompleteProjectionMock = Mock.Of<IEntityTypeProjection>();
+
+        // Act
+        var action = () => new EntityTypeProjections<Dog>([incompleteProjectionMock]);
+
+        // Assert
+        var exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(action);
+        Assert.AreEqual("entityTypeProjection", exception.ParamName);
     }
 
     [TestMethod]
-    public void Throwing_When_EntityTypeProjection_Is_Not_Fully_Implemented()
+    public void ProjectTo_Simple_Succeed()
     {
         // Arrange
-        var entityProjectionsMock = CreateEntityProjectionsMock(
-            _incompleteProjectionMock.Object);
+        var projection = new DogProjection();
+        var projections = new EntityTypeProjections<Dog>([projection]);
+
+        var entity = new Dog();
+        var query = new[] { entity }.AsQueryable();
 
         // Act
-        try
-        {
-            _ = entityProjectionsMock.Object;
-            Assert.Fail();
-        }
-        catch (TargetInvocationException exception)
-        when (exception.InnerException is ArgumentOutOfRangeException outOfRangeException
-            && outOfRangeException.ParamName == "entityTypeProjection")
-        {
-        }
+        var result = projections.ProjectTo<DogDto>(query, _dbContextMock);
+
+        // Assert
+        DogDto[] expected = [new DogDto { Id = $"DogDto-{entity.Id}" }];
+        CollectionAssert.AreEquivalent(expected, result.ToArray());
     }
 
-    private static Mock<EntityTypeProjections<SomeEntity>> CreateEntityProjectionsMock(
-        params IEntityTypeProjection[] projections)
+    [TestMethod]
+    public void ProjectTo_MultipleResultTypes_SupportAll()
     {
-        var entityProjectionsMock = new Mock<EntityTypeProjections<SomeEntity>>(
-            () => new EntityTypeProjections<SomeEntity>(
-                projections.ToHashSet()));
+        // Arrange
+        var entity = new Dog();
+        var query = new[] { entity }.AsQueryable();
 
-        return entityProjectionsMock;
+        var dogSummaryProjectionMock = new Mock<IEntityTypeProjection<Dog, DogSummaryDto>>();
+        dogSummaryProjectionMock
+            .Setup(mock => mock.Project(
+                query,
+                It.Is<ProjectionContext>(projectionContext => projectionContext.DbContext == _dbContextMock)))
+            .Returns(new[] { new DogSummaryDto { Name = $"summary-{entity.Id}" } }.AsQueryable());
+        var dogDtoProjection = new DogProjection();
+
+        var projections = new EntityTypeProjections<Dog>([dogDtoProjection, dogSummaryProjectionMock.Object]);
+
+        // Act
+        var dogDtoResult = projections.ProjectTo<DogDto>(query, _dbContextMock);
+        var dogSummaryDtoResult = projections.ProjectTo<DogSummaryDto>(query, _dbContextMock);
+
+        // Assert
+        DogDto[] expectedDogDtoResults = [new DogDto { Id = $"DogDto-{entity.Id}" }];
+        DogSummaryDto[] expectedDogSummaryDtoResults = [new DogSummaryDto { Name = $"summary-{entity.Id}" }];
+        CollectionAssert.AreEquivalent(expectedDogDtoResults, dogDtoResult.ToArray());
+        CollectionAssert.AreEquivalent(expectedDogSummaryDtoResults, dogSummaryDtoResult.ToArray());
     }
 
-    internal sealed class SomeEntity
+    [TestMethod]
+    public void ProjectTo_ImplementingMultipleProjections_BeSupported()
     {
+        // Arrange
+        var entity = new Dog();
+        var query = new[] { entity }.AsQueryable();
+
+        var multiProjection = new DogMultiProjection();
+        var projections = new EntityTypeProjections<Dog>([multiProjection]);
+
+        // Act
+        var dogDtoResult = projections.ProjectTo<DogDto>(query, _dbContextMock);
+        var dogSummaryDtoResult = projections.ProjectTo<DogSummaryDto>(query, _dbContextMock);
+
+        // Assert
+        DogDto[] expectedDogDtoResults = [new DogDto { Id = $"DogDto-{entity.Id}" }];
+        DogSummaryDto[] expectedDogSummaryDtoResults = [new DogSummaryDto { Name = $"DogSummary-{entity.Id}" }];
+        CollectionAssert.AreEquivalent(expectedDogDtoResults, dogDtoResult.ToArray());
+        CollectionAssert.AreEquivalent(expectedDogSummaryDtoResults, dogSummaryDtoResult.ToArray());
     }
 
-    internal sealed record SomeDto1
+    [TestMethod]
+    public void ProjectTo_MissingExactProjection_FallBackToBaseTypeProjection()
     {
+        // Arrange
+        var dogProjection = new DogProjection();
+        var projections = new EntityTypeProjections<Husky>([dogProjection]);
+        var entity = new Husky();
+        var query = new[] { entity }.AsQueryable();
+
+        // Act
+        var result = projections.ProjectTo<DogDto>(query, _dbContextMock);
+
+        // Assert
+        DogDto[] expected = [new DogDto { Id = $"DogDto-{entity.Id}" }];
+        CollectionAssert.AreEquivalent(expected, result.ToArray());
     }
 
-    internal sealed record SomeDto2
+    [TestMethod]
+    public void ProjectTo_Always_UseMostSpecificProjection()
     {
+        // Arrange
+        var entity = new Husky();
+        var query = new[] { entity }.AsQueryable();
+        DogDto[] expected = [new DogDto { Id = $"HuskyDto-{entity.Id}" }];
+        var huskyProjectionMock = new Mock<IEntityTypeProjection<Husky, DogDto>>();
+        huskyProjectionMock
+            .Setup(mock => mock.Project(
+                query,
+                It.Is<ProjectionContext>(projectionContext => projectionContext.DbContext == _dbContextMock)))
+            .Returns(expected.AsQueryable());
+        var dogProjection = new DogProjection();
+
+        var projections = new EntityTypeProjections<Husky>([dogProjection, huskyProjectionMock.Object]);
+
+        // Act
+        var result = projections.ProjectTo<DogDto>(query, _dbContextMock);
+
+        // Assert
+        CollectionAssert.AreEquivalent(expected, result.ToArray());
     }
 
-    internal sealed record SomeDto3
+    [TestMethod]
+    public void ProjectTo_MissingProjection_InvalidOperationException()
     {
+        // Arrange
+        var projections = new EntityTypeProjections<Dog>([new DogProjection()]);
+        var query = new[] { new Dog() }.AsQueryable();
+
+        // Act
+        var action = () => projections.ProjectTo<DogSummaryDto>(query, _dbContextMock);
+
+        // Assert
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(action);
+
+        Assert.Contains("No projection specified", exception.Message);
+        Assert.Contains(nameof(Dog), exception.Message);
+        Assert.Contains(nameof(DogSummaryDto), exception.Message);
     }
 }

--- a/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Linq;
 using System.Reflection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using OneBeyond.Studio.DataAccess.EFCore.Projections;
 
@@ -12,13 +9,13 @@ public sealed class EntityTypeProjectionsTests
 {
     private readonly Mock<IEntityTypeProjection<SomeEntity, SomeDto1>> _dto1ProjectionMock;
     private readonly Mock<IEntityTypeProjection<SomeEntity, SomeDto2>> _dto2ProjectionMock;
-    private readonly Mock<IEntityTypeProjection<SomeEntity>> _incompleteProjectionMock;    
+    private readonly Mock<IEntityTypeProjection> _incompleteProjectionMock;
 
     public EntityTypeProjectionsTests()
     {
         _dto1ProjectionMock = new Mock<IEntityTypeProjection<SomeEntity, SomeDto1>>();
         _dto2ProjectionMock = _dto1ProjectionMock.As<IEntityTypeProjection<SomeEntity, SomeDto2>>();
-        _incompleteProjectionMock = new Mock<IEntityTypeProjection<SomeEntity>>();
+        _incompleteProjectionMock = new Mock<IEntityTypeProjection>();
 
     }
 
@@ -26,7 +23,7 @@ public sealed class EntityTypeProjectionsTests
     public void Throwing_When_EntityTypeProjection_Is_Not_Fully_Implemented()
     {
         // Arrange
-        var entityProjectionsMock = CreateEntityProjectionsMock(            
+        var entityProjectionsMock = CreateEntityProjectionsMock(
             _incompleteProjectionMock.Object);
 
         // Act
@@ -42,12 +39,12 @@ public sealed class EntityTypeProjectionsTests
         }
     }
 
-    private static Mock<EntityTypeProjections<SomeEntity>> CreateEntityProjectionsMock(        
-        params IEntityTypeProjection<SomeEntity>[] projections)
+    private static Mock<EntityTypeProjections<SomeEntity>> CreateEntityProjectionsMock(
+        params IEntityTypeProjection[] projections)
     {
         var entityProjectionsMock = new Mock<EntityTypeProjections<SomeEntity>>(
             () => new EntityTypeProjections<SomeEntity>(
-                projections.ToHashSet()));        
+                projections.ToHashSet()));
 
         return entityProjectionsMock;
     }

--- a/src/OneBeyond.Studio.DataAccess.EFCore/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 using EnsureThat;
 using Microsoft.EntityFrameworkCore;
@@ -65,7 +64,7 @@ public static class ServiceCollectionExtensions
 
         services.Scan((scan) =>
             scan.FromAssemblies(entityTypeProjectionsAssemblies)
-                .AddClasses((classes) => classes.AssignableTo(typeof(IEntityTypeProjection<>)))
+                .AddClasses((classes) => classes.AssignableTo(typeof(IEntityTypeProjection)))
                     .AsImplementedInterfaces()
                     .WithSingletonLifetime());
 

--- a/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
@@ -1,31 +1,105 @@
+using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using EnsureThat;
 using Microsoft.EntityFrameworkCore;
 using OneBeyond.Studio.Crosscuts.Reflection;
 
 namespace OneBeyond.Studio.DataAccess.EFCore.Projections;
 
-internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
-    where TEntity : class
+/// <summary>
+/// Provides an abstract base class for managing and optimizing entity type projections.
+/// </summary>
+/// <remarks>This class supports the creation and caching of projection delegates for entity types.</remarks>
+internal abstract class EntityTypeProjections
 {
-    private static readonly MethodInfo DoProjectMethodInfo = Reflector
-        .MethodFrom(() => DoProject<object, object>(default!, default!, default!))
+    private static readonly ConditionalWeakTable<IEntityTypeProjection, ConcurrentDictionary<(Type EntityType, Type ResultType), ProjectFunc>> _delegates = [];
+
+    protected delegate object ProjectFunc(IQueryable entityQuery, ProjectionContext context);
+
+    protected static Type ProjectionInterfaceType { get; } = typeof(IEntityTypeProjection<,>);
+    protected static Type QueryableType { get; } = typeof(IQueryable<>);
+
+    protected static MethodInfo ProjectMethodInfo { get; } = Reflector
+        .MethodFrom(() => Project<object, object>(default!, default!, default!))
         .GetGenericMethodDefinition();
 
-    private readonly IReadOnlyDictionary<(Type EntityType, Type ResultType), DoProjectFunc> _doProjectFuncMap;
+    protected static IQueryable<TResult> Project<TSource, TResult>(
+        IEntityTypeProjection<TSource, TResult> entityTypeProjection,
+        IQueryable<TSource> entityQuery,
+        ProjectionContext context)
+        where TSource : class
+        => entityTypeProjection.Project(entityQuery, context);
+
+    protected static ProjectFunc GetOrCompileProjectFunc(
+        IEntityTypeProjection entityTypeProjection,
+        Type entityType,
+        Type resultType)
+    {
+        var instanceCache = _delegates.GetOrCreateValue(entityTypeProjection);
+
+        var key = (entityType, resultType);
+
+        return instanceCache.GetOrAdd(key, _ =>
+        {
+            var interfaceType = ProjectionInterfaceType.MakeGenericType(entityType, resultType);
+            var projectionInstance = Expression.Constant(entityTypeProjection, interfaceType);
+
+            var entityQueryParam = Expression.Parameter(typeof(IQueryable), "entityQuery");
+            var castedEntityQuery = Expression.Convert(entityQueryParam, QueryableType.MakeGenericType(entityType));
+            var projectionContextParam = Expression.Parameter(typeof(ProjectionContext), "context");
+
+            var projectCall = Expression.Call(
+                ProjectMethodInfo.MakeGenericMethod(entityType, resultType),
+                projectionInstance,
+                castedEntityQuery,
+                projectionContextParam);
+
+            var projectLambda = Expression.Lambda<ProjectFunc>(
+                projectCall,
+                entityQueryParam,
+                projectionContextParam);
+
+            return projectLambda.Compile();
+        });
+    }
+}
+
+/// <summary>
+/// Provides functionality to project entities of type <typeparamref name="TEntity"/> into different result types based on registered projections.
+/// </summary>
+/// <remarks>It builds a hierarchy of entity types to support inheritance-based projections.</remarks>
+internal sealed class EntityTypeProjections<TEntity> : EntityTypeProjections, IEntityTypeProjections<TEntity>
+    where TEntity : class
+{
+    private readonly FrozenDictionary<(Type EntityType, Type ResultType), ProjectFunc> _projectFuncMap;
+    private readonly IReadOnlyList<Type> _entityTypeHierarchy;
 
     public EntityTypeProjections(
         IEnumerable<IEntityTypeProjection> entityTypeProjections)
     {
         EnsureArg.IsNotNull(entityTypeProjections, nameof(entityTypeProjections));
 
-        _doProjectFuncMap = entityTypeProjections
-            .SelectMany(CreateDoProjectFuncMap)
-            .Where(item => item.EntityType.IsAssignableFrom(typeof(TEntity)))
-            .ToDictionary(item => (item.EntityType, item.ResultType), item => item.DoProject);
+        var entityType = typeof(TEntity);
+        _projectFuncMap = entityTypeProjections
+            .SelectMany(projection => CreateProjectFuncMap(projection, entityType))
+            .ToFrozenDictionary(item => (item.EntityType, item.ResultType), item => item.ProjectFunc);
+
+        _entityTypeHierarchy = BuildEntityTypeHierarchy(entityType);
     }
 
+    /// <summary>
+    /// Projects the results of the specified entity query to a new type using a registered mapping function.
+    /// </summary>
+    /// <typeparam name="TResult">The type to which the entities are projected.</typeparam>
+    /// <param name="entityQuery">The <see cref="IQueryable{TEntity}"/> collection of entities to project.</param>
+    /// <param name="dbContext">The <see cref="DbContext"/> used to resolve projection mappings.</param>
+    /// <returns>An <see cref="IQueryable{TResult}"/> representing the projected  results of the query.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if no projection mapping is registered from <typeparamref name="TEntity"/> (or any of its base types) to the specified <typeparamref name="TResult"/>.
+    /// </exception>
     public IQueryable<TResult> ProjectTo<TResult>(IQueryable<TEntity> entityQuery, DbContext dbContext)
     {
         EnsureArg.IsNotNull(entityQuery, nameof(entityQuery));
@@ -34,72 +108,60 @@ internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
         var projectionContext = new ProjectionContext(dbContext);
         var resultType = typeof(TResult);
 
-        var entityType = typeof(TEntity);
-        while (entityType is not null)
+        foreach (var entityType in _entityTypeHierarchy)
         {
-            var key = (entityType, resultType);
-            if (_doProjectFuncMap.TryGetValue(key, out var doProject))
+            if (_projectFuncMap.TryGetValue((entityType, resultType), out var projectFunc))
             {
-                return (IQueryable<TResult>)doProject(entityQuery, projectionContext);
+                return (IQueryable<TResult>)projectFunc(entityQuery, projectionContext);
             }
-            entityType = entityType.BaseType;
         }
 
-        throw new InvalidOperationException($"No projection specified from '{typeof(TEntity).FullName}' (or any of its base types) to '{typeof(TResult).FullName}'.");
+        throw new InvalidOperationException($"No projection specified from '{typeof(TEntity).FullName}' (or any of its base types) to '{resultType.FullName}'.");
     }
 
-    private static IReadOnlyCollection<(Type EntityType, Type ResultType, DoProjectFunc DoProject)> CreateDoProjectFuncMap(
-        IEntityTypeProjection entityTypeProjection)
+    private static List<Type> BuildEntityTypeHierarchy(Type entityType)
+    {
+        var hierarchy = new List<Type>();
+        var currentType = entityType;
+
+        while (currentType != typeof(object) && currentType is not null)
+        {
+            hierarchy.Add(currentType);
+            currentType = currentType.BaseType;
+        }
+
+        return hierarchy;
+    }
+
+    private static List<(Type EntityType, Type ResultType, ProjectFunc ProjectFunc)> CreateProjectFuncMap(
+        IEntityTypeProjection entityTypeProjection,
+        Type targetEntityType)
     {
         var projectionType = entityTypeProjection.GetType();
-        var doProjectFuncMap = projectionType.GetInterfaces()
-            .Where(interfaceType => interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEntityTypeProjection<,>))
-            .Select(interfaceType =>
+        var projectionsFound = new List<(Type EntityType, Type ResultType, ProjectFunc ProjectFunc)>();
+        var hasAnyProjectionInterface = false;
+
+        foreach (var interfaceType in projectionType.GetInterfaces())
+        {
+            if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == ProjectionInterfaceType)
             {
+                hasAnyProjectionInterface = true;
                 var typeArguments = interfaceType.GetGenericArguments();
                 var entityType = typeArguments[0];
-                var resultType = typeArguments[1];
-                return (entityType, resultType, CompileDoProjectFunc(entityTypeProjection, entityType, resultType));
-            })
-            .ToList();
 
-        return doProjectFuncMap.Count == 0
-            ? throw new ArgumentOutOfRangeException(
+                if (entityType.IsAssignableFrom(targetEntityType))
+                {
+                    var resultType = typeArguments[1];
+                    projectionsFound.Add((entityType, resultType, GetOrCompileProjectFunc(entityTypeProjection, entityType, resultType)));
+                }
+            }
+        }
+
+        return hasAnyProjectionInterface
+            ? projectionsFound
+            : throw new ArgumentOutOfRangeException(
                 nameof(entityTypeProjection),
-                $"Entity type projection of the {projectionType.FullName} type is incomplete. Consider implementing at least one projection.")
-            : doProjectFuncMap;
+                entityTypeProjection,
+                $"Entity type projection of the {projectionType.FullName} type is incomplete. Consider implementing at least one projection.");
     }
-
-    private static DoProjectFunc CompileDoProjectFunc(
-        IEntityTypeProjection entityTypeProjection,
-        Type entityType,
-        Type resultType)
-    {
-        var interfaceType = typeof(IEntityTypeProjection<,>).MakeGenericType(entityType, resultType);
-        var projectionInstance = Expression.Constant(entityTypeProjection, interfaceType);
-        var entityQueryParam = Expression.Parameter(typeof(IQueryable<>).MakeGenericType(entityType), "entityQuery");
-        var projectionContextParam = Expression.Parameter(typeof(ProjectionContext), "context");
-
-        var doProjectCall = Expression.Call(
-            DoProjectMethodInfo.MakeGenericMethod(entityType, resultType),
-            projectionInstance,
-            entityQueryParam,
-            projectionContextParam);
-
-        var doProjectLambda = Expression.Lambda<DoProjectFunc>(
-            doProjectCall,
-            entityQueryParam,
-            projectionContextParam);
-
-        return doProjectLambda.Compile();
-    }
-
-    private static IQueryable<TResult> DoProject<TSource, TResult>(
-        IEntityTypeProjection<TSource, TResult> entityTypeProjection,
-        IQueryable<TSource> entityQuery,
-        ProjectionContext context)
-        where TSource : class
-        => entityTypeProjection.Project(entityQuery, context);
-
-    private delegate object DoProjectFunc(IQueryable entityQuery, ProjectionContext context);
 }

--- a/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using EnsureThat;
@@ -16,16 +13,16 @@ internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
         .MethodFrom(() => DoProject<object>(default!, default!, default!))
         .GetGenericMethodDefinition();
 
-    private readonly IReadOnlyDictionary<Type, DoProjectFunc> _doProjectFuncMap;    
+    private readonly IReadOnlyDictionary<Type, DoProjectFunc> _doProjectFuncMap;
 
     public EntityTypeProjections(
         IEnumerable<IEntityTypeProjection<TEntity>> entityTypeProjections)
     {
-        EnsureArg.IsNotNull(entityTypeProjections, nameof(entityTypeProjections));        
+        EnsureArg.IsNotNull(entityTypeProjections, nameof(entityTypeProjections));
 
         _doProjectFuncMap = entityTypeProjections
             .SelectMany(CreateDoProjectFuncMap)
-            .ToDictionary((item) => item.ResultType, (item) => item.DoProject);        
+            .ToDictionary(item => item.ResultType, item => item.DoProject);
     }
 
     public IQueryable<TResult> ProjectTo<TResult>(IQueryable<TEntity> entityQuery, DbContext dbContext)
@@ -35,27 +32,27 @@ internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
 
         var projectionContext = new ProjectionContext(dbContext);
         return _doProjectFuncMap.TryGetValue(typeof(TResult), out var doProject)
-            ? (IQueryable<TResult>)doProject(
-                entityQuery,
-                projectionContext)
+            ? (IQueryable<TResult>)doProject(entityQuery, projectionContext)
             : throw new InvalidOperationException($"No projection specified from '{typeof(TEntity).FullName}' to '{typeof(TResult).FullName}'.");
-    }    
+    }
 
     private static IReadOnlyCollection<(Type ResultType, DoProjectFunc DoProject)> CreateDoProjectFuncMap(
         IEntityTypeProjection<TEntity> entityTypeProjection)
     {
-        var doProjectFuncMap = entityTypeProjection.GetType().GetInterfaces()
-            .Where((interfaceType) =>
-                interfaceType.IsGenericType
-                && interfaceType.GetGenericTypeDefinition() == typeof(IEntityTypeProjection<,>))
-            .Select((interfaceType) => interfaceType.GetGenericArguments()[1])
-            .Select((resultType) => (resultType, CompileDoProjectFunc(entityTypeProjection, resultType)))
+        var entityType = entityTypeProjection.GetType();
+        var doProjectFuncMap = entityType.GetInterfaces()
+            .Where(interfaceType => interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEntityTypeProjection<,>))
+            .Select(interfaceType =>
+            {
+                var resultType = interfaceType.GetGenericArguments()[1];
+                return (resultType, CompileDoProjectFunc(entityTypeProjection, resultType));
+            })
             .ToList();
+
         return doProjectFuncMap.Count == 0
             ? throw new ArgumentOutOfRangeException(
                 nameof(entityTypeProjection),
-                $"Entity type projection of the {entityTypeProjection.GetType().FullName} type is incomplete. " +
-                "Consider implementing at least one projection.")
+                $"Entity type projection of the {entityType.FullName} type is incomplete. Consider implementing at least one projection.")
             : doProjectFuncMap;
     }
 
@@ -67,23 +64,26 @@ internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
         var projectionInstance = Expression.Constant(entityTypeProjection, interfaceType);
         var entityQueryParam = Expression.Parameter(typeof(IQueryable<>).MakeGenericType(typeof(TEntity)), "entityQuery");
         var projectionContextParam = Expression.Parameter(typeof(ProjectionContext), "context");
+
         var doProjectCall = Expression.Call(
             DoProjectMethodInfo.MakeGenericMethod(resultType),
             projectionInstance,
             entityQueryParam,
             projectionContextParam);
+
         var doProjectLambda = Expression.Lambda<DoProjectFunc>(
             doProjectCall,
             entityQueryParam,
             projectionContextParam);
+
         return doProjectLambda.Compile();
     }
 
     private static IQueryable<TResult> DoProject<TResult>(
         IEntityTypeProjection<TEntity, TResult> entityTypeProjection,
-        IQueryable<TEntity> enityQuery,
+        IQueryable<TEntity> entityQuery,
         ProjectionContext context)
-        => entityTypeProjection.Project(enityQuery, context);
+        => entityTypeProjection.Project(entityQuery, context);
 
     private delegate object DoProjectFunc(IQueryable<TEntity> entityQuery, ProjectionContext context);
 }

--- a/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
@@ -10,19 +10,20 @@ internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
     where TEntity : class
 {
     private static readonly MethodInfo DoProjectMethodInfo = Reflector
-        .MethodFrom(() => DoProject<object>(default!, default!, default!))
+        .MethodFrom(() => DoProject<object, object>(default!, default!, default!))
         .GetGenericMethodDefinition();
 
-    private readonly IReadOnlyDictionary<Type, DoProjectFunc> _doProjectFuncMap;
+    private readonly IReadOnlyDictionary<(Type EntityType, Type ResultType), DoProjectFunc> _doProjectFuncMap;
 
     public EntityTypeProjections(
-        IEnumerable<IEntityTypeProjection<TEntity>> entityTypeProjections)
+        IEnumerable<IEntityTypeProjection> entityTypeProjections)
     {
         EnsureArg.IsNotNull(entityTypeProjections, nameof(entityTypeProjections));
 
         _doProjectFuncMap = entityTypeProjections
             .SelectMany(CreateDoProjectFuncMap)
-            .ToDictionary(item => item.ResultType, item => item.DoProject);
+            .Where(item => item.EntityType.IsAssignableFrom(typeof(TEntity)))
+            .ToDictionary(item => (item.EntityType, item.ResultType), item => item.DoProject);
     }
 
     public IQueryable<TResult> ProjectTo<TResult>(IQueryable<TEntity> entityQuery, DbContext dbContext)
@@ -31,42 +32,56 @@ internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
         EnsureArg.IsNotNull(dbContext, nameof(dbContext));
 
         var projectionContext = new ProjectionContext(dbContext);
-        return _doProjectFuncMap.TryGetValue(typeof(TResult), out var doProject)
-            ? (IQueryable<TResult>)doProject(entityQuery, projectionContext)
-            : throw new InvalidOperationException($"No projection specified from '{typeof(TEntity).FullName}' to '{typeof(TResult).FullName}'.");
+        var resultType = typeof(TResult);
+
+        var entityType = typeof(TEntity);
+        while (entityType is not null)
+        {
+            var key = (entityType, resultType);
+            if (_doProjectFuncMap.TryGetValue(key, out var doProject))
+            {
+                return (IQueryable<TResult>)doProject(entityQuery, projectionContext);
+            }
+            entityType = entityType.BaseType;
+        }
+
+        throw new InvalidOperationException($"No projection specified from '{typeof(TEntity).FullName}' (or any of its base types) to '{typeof(TResult).FullName}'.");
     }
 
-    private static IReadOnlyCollection<(Type ResultType, DoProjectFunc DoProject)> CreateDoProjectFuncMap(
-        IEntityTypeProjection<TEntity> entityTypeProjection)
+    private static IReadOnlyCollection<(Type EntityType, Type ResultType, DoProjectFunc DoProject)> CreateDoProjectFuncMap(
+        IEntityTypeProjection entityTypeProjection)
     {
-        var entityType = entityTypeProjection.GetType();
-        var doProjectFuncMap = entityType.GetInterfaces()
+        var projectionType = entityTypeProjection.GetType();
+        var doProjectFuncMap = projectionType.GetInterfaces()
             .Where(interfaceType => interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEntityTypeProjection<,>))
             .Select(interfaceType =>
             {
-                var resultType = interfaceType.GetGenericArguments()[1];
-                return (resultType, CompileDoProjectFunc(entityTypeProjection, resultType));
+                var typeArguments = interfaceType.GetGenericArguments();
+                var entityType = typeArguments[0];
+                var resultType = typeArguments[1];
+                return (entityType, resultType, CompileDoProjectFunc(entityTypeProjection, entityType, resultType));
             })
             .ToList();
 
         return doProjectFuncMap.Count == 0
             ? throw new ArgumentOutOfRangeException(
                 nameof(entityTypeProjection),
-                $"Entity type projection of the {entityType.FullName} type is incomplete. Consider implementing at least one projection.")
+                $"Entity type projection of the {projectionType.FullName} type is incomplete. Consider implementing at least one projection.")
             : doProjectFuncMap;
     }
 
     private static DoProjectFunc CompileDoProjectFunc(
-        IEntityTypeProjection<TEntity> entityTypeProjection,
+        IEntityTypeProjection entityTypeProjection,
+        Type entityType,
         Type resultType)
     {
-        var interfaceType = typeof(IEntityTypeProjection<,>).MakeGenericType(typeof(TEntity), resultType);
+        var interfaceType = typeof(IEntityTypeProjection<,>).MakeGenericType(entityType, resultType);
         var projectionInstance = Expression.Constant(entityTypeProjection, interfaceType);
-        var entityQueryParam = Expression.Parameter(typeof(IQueryable<>).MakeGenericType(typeof(TEntity)), "entityQuery");
+        var entityQueryParam = Expression.Parameter(typeof(IQueryable<>).MakeGenericType(entityType), "entityQuery");
         var projectionContextParam = Expression.Parameter(typeof(ProjectionContext), "context");
 
         var doProjectCall = Expression.Call(
-            DoProjectMethodInfo.MakeGenericMethod(resultType),
+            DoProjectMethodInfo.MakeGenericMethod(entityType, resultType),
             projectionInstance,
             entityQueryParam,
             projectionContextParam);
@@ -79,11 +94,12 @@ internal class EntityTypeProjections<TEntity> : IEntityTypeProjections<TEntity>
         return doProjectLambda.Compile();
     }
 
-    private static IQueryable<TResult> DoProject<TResult>(
-        IEntityTypeProjection<TEntity, TResult> entityTypeProjection,
-        IQueryable<TEntity> entityQuery,
+    private static IQueryable<TResult> DoProject<TSource, TResult>(
+        IEntityTypeProjection<TSource, TResult> entityTypeProjection,
+        IQueryable<TSource> entityQuery,
         ProjectionContext context)
+        where TSource : class
         => entityTypeProjection.Project(entityQuery, context);
 
-    private delegate object DoProjectFunc(IQueryable<TEntity> entityQuery, ProjectionContext context);
+    private delegate object DoProjectFunc(IQueryable entityQuery, ProjectionContext context);
 }

--- a/src/OneBeyond.Studio.DataAccess.EFCore/Projections/IEntityTypeProjection.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/Projections/IEntityTypeProjection.cs
@@ -1,14 +1,9 @@
-using System.Linq;
-
 namespace OneBeyond.Studio.DataAccess.EFCore.Projections;
 
-public interface IEntityTypeProjection<TEntity>
-    where TEntity : class
-{
-}
+public interface IEntityTypeProjection { }
 
-public interface IEntityTypeProjection<TEntity, TResult> : IEntityTypeProjection<TEntity>
+public interface IEntityTypeProjection<TEntity, TResult> : IEntityTypeProjection
     where TEntity : class
 {
-    IQueryable<TResult> Project(IQueryable<TEntity> entityQuery, ProjectionContext context);
+    public IQueryable<TResult> Project(IQueryable<TEntity> entityQuery, ProjectionContext context);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Update `EntityTypeProjections` to store projections **by entity and result type**, enabling projections to implement multiple projection interfaces and lookup for base entity type projections.
  - Projections search the entity inheritance chain to find the most specific match.
- Replace generic `IEntityTypeProjection<TEntity>` with a non-generic marker interface ([S2326](https://web.archive.org/web/20251117061724/https://rules.sonarsource.com/csharp/RSPEC-2326/)).
- Fix parameter typo and [CA1859](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859) violations.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#170

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows a projection to implement multiple interfaces and use a projection defined for a base class to be used automatically if there was no exact match defined.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
