### PR TITLE
Automatically apply AsNoTracking() to entity type projections

### DIFF
--- a/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.TestModels.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.TestModels.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using OneBeyond.Studio.Domain.SharedKernel.Entities;
 
 namespace OneBeyond.Studio.DataAccess.EFCore.Tests.Projections;
@@ -24,5 +25,17 @@ public sealed partial class EntityTypeProjectionsTests
     internal sealed record DogSummaryDto
     {
         public required string Name { get; init; }
+    }
+
+    internal sealed class DogDbContext : DbContext
+    {
+        public DogDbContext(DbContextOptions options) : base(options) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Animal>().HasKey(e => e.Id);
+            modelBuilder.Entity<Dog>();
+        }
     }
 }

--- a/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore.Tests/Projections/EntityTypeProjectionsTests.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using OneBeyond.Studio.DataAccess.EFCore.Projections;
@@ -163,5 +164,75 @@ public sealed partial class EntityTypeProjectionsTests
         Assert.Contains("No projection specified", exception.Message);
         Assert.Contains(nameof(Dog), exception.Message);
         Assert.Contains(nameof(DogSummaryDto), exception.Message);
+    }
+
+    [Fact]
+    public void ProjectTo_NullEntityQuery_ArgumentNullException()
+    {
+        // Arrange
+        var projections = new EntityTypeProjections<Dog>([new DogProjection()]);
+
+        // Act
+        var action = () => projections.ProjectTo<DogDto>(null!, _dbContextMock);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(action);
+    }
+
+    [Fact]
+    public void ProjectTo_NullDbContext_ArgumentNullException()
+    {
+        // Arrange
+        var projections = new EntityTypeProjections<Dog>([new DogProjection()]);
+        var query = new[] { new Dog() }.AsQueryable();
+
+        // Act
+        var action = () => projections.ProjectTo<DogDto>(query, null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(action);
+    }
+
+    [Fact]
+    public void ProjectTo_EFCoreQuery_QueryPassedToProjectionIsAsNoTracking()
+    {
+        // Arrange
+        var dbContextOptions = new DbContextOptionsBuilder()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var efDbContext = new DogDbContext(dbContextOptions);
+
+        IQueryable<Dog>? capturedQuery = null;
+        var projectionMock = new Mock<IEntityTypeProjection<Dog, DogDto>>();
+        projectionMock
+            .Setup(p => p.Project(It.IsAny<IQueryable<Dog>>(), It.IsAny<ProjectionContext>()))
+            .Callback<IQueryable<Dog>, ProjectionContext>((query, _) => capturedQuery = query)
+            .Returns(Array.Empty<DogDto>().AsQueryable());
+
+        var projections = new EntityTypeProjections<Dog>([projectionMock.Object]);
+
+        // Act
+        projections.ProjectTo<DogDto>(efDbContext.Set<Dog>(), _dbContextMock);
+
+        // Assert
+        Assert.NotNull(capturedQuery);
+        var expression = Assert.IsAssignableFrom<MethodCallExpression>(capturedQuery.Expression);
+        Assert.Equal(nameof(EntityFrameworkQueryableExtensions.AsNoTracking), expression.Method.Name);
+    }
+
+    [Fact]
+    public void ProjectTo_ProjectionForDerivedEntityType_NotAppliedToBaseEntityType()
+    {
+        // Arrange
+        var huskyProjectionMock = new Mock<IEntityTypeProjection<Husky, DogDto>>();
+        var projections = new EntityTypeProjections<Dog>([huskyProjectionMock.Object]);
+        var query = new[] { new Dog() }.AsQueryable();
+
+        // Act
+        var action = () => projections.ProjectTo<DogDto>(query, _dbContextMock);
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(action);
     }
 }

--- a/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/Projections/EntityTypeProjections.cs
@@ -31,7 +31,7 @@ internal abstract class EntityTypeProjections
         IQueryable<TSource> entityQuery,
         ProjectionContext context)
         where TSource : class
-        => entityTypeProjection.Project(entityQuery, context);
+        => entityTypeProjection.Project(entityQuery.AsNoTracking(), context);
 
     protected static ProjectFunc GetOrCompileProjectFunc(
         IEntityTypeProjection entityTypeProjection,


### PR DESCRIPTION
Closes #183 