### PR TITLE
docs: add XML docs for repository types

### DIFF
--- a/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRORepository.cs
+++ b/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRORepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using OneBeyond.Studio.Application.SharedKernel.Repositories.Exceptions;
 using OneBeyond.Studio.Application.SharedKernel.Specifications;
 using OneBeyond.Studio.Domain.SharedKernel.Entities;
 using OneBeyond.Studio.Domain.SharedKernel.Specifications;
@@ -10,10 +11,20 @@ using OneBeyond.Studio.Domain.SharedKernel.Specifications;
 namespace OneBeyond.Studio.Application.SharedKernel.Repositories;
 
 /// <summary>
-/// Represents a repository with read-only operations.
+/// Read-only repository exposing query operations over <typeparamref name="TEntity"/>.
+/// Results are detached.
 /// </summary>
+/// <typeparam name="TEntity">Type of the queried entity.</typeparam>
 public interface IRORepository<TEntity>
 {
+    /// <summary>
+    /// Returns the entities matching <paramref name="filter"/>, or all entities when it is <see langword="null"/>.
+    /// </summary>
+    /// <param name="filter">Predicate to match, or <see langword="null"/> to match every entity.</param>
+    /// <param name="includes">Related object graph to load alongside each entity, or <see langword="null"/> for none.</param>
+    /// <param name="paging">Slice of the result set to return, or <see langword="null"/> for all matches.</param>
+    /// <param name="sortings">Ordering to apply.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<IReadOnlyCollection<TEntity>> ListAsync(
         Expression<Func<TEntity, bool>>? filter = default,
         Includes<TEntity>? includes = default,
@@ -21,6 +32,21 @@ public interface IRORepository<TEntity>
         IReadOnlyCollection<Sorting<TEntity>>? sortings = default,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Projects the entities matching <paramref name="preFilter"/> onto <typeparamref name="TResultDto"/>,
+    /// then returns those matching <paramref name="filter"/>.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="preFilter"/> is applied in entity space before projection; <paramref name="filter"/>
+    /// is applied in result space after it. The projection is resolved from the registered mapping for
+    /// <typeparamref name="TResultDto"/>.
+    /// </remarks>
+    /// <typeparam name="TResultDto">Type each entity is projected onto.</typeparam>
+    /// <param name="preFilter">Predicate applied to entities before projection, or <see langword="null"/> to match all.</param>
+    /// <param name="filter">Predicate applied to projected results, or <see langword="null"/> to match all.</param>
+    /// <param name="paging">Slice of the result set to return, or <see langword="null"/> for all matches.</param>
+    /// <param name="sortings">Ordering to apply.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<IReadOnlyCollection<TResultDto>> ListAsync<TResultDto>(
         Expression<Func<TEntity, bool>>? preFilter,
         Expression<Func<TResultDto, bool>>? filter = default,
@@ -28,6 +54,16 @@ public interface IRORepository<TEntity>
         IReadOnlyCollection<Sorting<TResultDto>>? sortings = default,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns the entities matching <paramref name="filter"/> projected onto <typeparamref name="TResultDto"/>
+    /// via <paramref name="projection"/>.
+    /// </summary>
+    /// <typeparam name="TResultDto">Type each entity is projected onto.</typeparam>
+    /// <param name="projection">Expression mapping an entity to a result. Translated to the query, not run in memory.</param>
+    /// <param name="filter">Predicate applied to entities before projection, or <see langword="null"/> to match all.</param>
+    /// <param name="paging">Slice of the result set to return, or <see langword="null"/> for all matches.</param>
+    /// <param name="sortings">Ordering applied to entities before projection.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<IReadOnlyCollection<TResultDto>> ListAsync<TResultDto>(
         Expression<Func<TEntity, TResultDto>> projection,
         Expression<Func<TEntity, bool>>? filter = default,
@@ -35,19 +71,46 @@ public interface IRORepository<TEntity>
         IReadOnlyCollection<Sorting<TEntity>>? sortings = default,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Counts the entities matching <paramref name="filter"/>, or all entities when it is <see langword="null"/>.
+    /// </summary>
+    /// <param name="filter">Predicate to match, or <see langword="null"/> to count every entity.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<int> CountAsync(
         Expression<Func<TEntity, bool>>? filter = default,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Counts the entities matching <paramref name="preFilter"/> whose <typeparamref name="TResultDto"/>
+    /// projection matches <paramref name="filter"/>.
+    /// </summary>
+    /// <typeparam name="TResultDto">Type each entity is projected onto.</typeparam>
+    /// <param name="preFilter">Predicate applied to entities before projection, or <see langword="null"/> to match all.</param>
+    /// <param name="filter">Predicate applied to projected results, or <see langword="null"/> to match all.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<int> CountAsync<TResultDto>(
         Expression<Func<TEntity, bool>>? preFilter,
         Expression<Func<TResultDto, bool>>? filter = default,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Determines whether any entity matches <paramref name="filter"/>, or whether any entity exists
+    /// when it is <see langword="null"/>.
+    /// </summary>
+    /// <param name="filter">Predicate to match, or <see langword="null"/> to match every entity.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<bool> AnyAsync(
         Expression<Func<TEntity, bool>>? filter = default,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Determines whether any entity matching <paramref name="preFilter"/> has a <typeparamref name="TResultDto"/>
+    /// projection matching <paramref name="filter"/>.
+    /// </summary>
+    /// <typeparam name="TResultDto">Type each entity is projected onto.</typeparam>
+    /// <param name="preFilter">Predicate applied to entities before projection, or <see langword="null"/> to match all.</param>
+    /// <param name="filter">Predicate applied to projected results, or <see langword="null"/> to match all.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<bool> AnyAsync<TResultDto>(
         Expression<Func<TEntity, bool>>? preFilter,
         Expression<Func<TResultDto, bool>>? filter = default,
@@ -55,21 +118,54 @@ public interface IRORepository<TEntity>
 }
 
 /// <summary>
-/// Represents a repository with read-only operations.
+/// Read-only repository that adds identifier-based lookups for an entity keyed by
+/// <typeparamref name="TEntityId"/>.
 /// </summary>
+/// <typeparam name="TEntity">Type of the queried entity.</typeparam>
+/// <typeparam name="TEntityId">Type of the entity identifier.</typeparam>
 public interface IRORepository<TEntity, TEntityId> : IRORepository<TEntity>
     where TEntity : DomainEntity<TEntityId>
     where TEntityId : notnull
 {
+    /// <summary>
+    /// Returns the entity identified by <paramref name="entityId"/>.
+    /// </summary>
+    /// <param name="entityId">Identifier of the entity to load.</param>
+    /// <param name="includes">Related object graph to load alongside the entity, or <see langword="null"/> for none.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The matching entity; never <see langword="null"/>.</returns>
+    /// <exception cref="EntityNotFoundException">No entity with <paramref name="entityId"/> exists.</exception>
+    /// <exception cref="EntityAccessDeniedException">The entity exists but the active read policy denies access to it.</exception>
     Task<TEntity> GetByIdAsync(
         TEntityId entityId,
         Includes<TEntity>? includes,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns the entity identified by <paramref name="entityId"/> projected onto <typeparamref name="TResultDto"/>
+    /// using the registered mapping.
+    /// </summary>
+    /// <typeparam name="TResultDto">Type the entity is projected onto.</typeparam>
+    /// <param name="entityId">Identifier of the entity to load.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The projected result; never <see langword="null"/>.</returns>
+    /// <exception cref="EntityNotFoundException">No entity with <paramref name="entityId"/> exists.</exception>
+    /// <exception cref="EntityAccessDeniedException">The entity exists but the active read policy denies access to it.</exception>
     Task<TResultDto> GetByIdAsync<TResultDto>(
         TEntityId entityId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns the entity identified by <paramref name="entityId"/> projected onto <typeparamref name="TResultDto"/>
+    /// via <paramref name="projection"/>.
+    /// </summary>
+    /// <typeparam name="TResultDto">Type the entity is projected onto.</typeparam>
+    /// <param name="entityId">Identifier of the entity to load.</param>
+    /// <param name="projection">Expression mapping the entity to a result. Translated to the query, not run in memory.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The projected result; never <see langword="null"/>.</returns>
+    /// <exception cref="EntityNotFoundException">No entity with <paramref name="entityId"/> exists.</exception>
+    /// <exception cref="EntityAccessDeniedException">The entity exists but the active read policy denies access to it.</exception>
     Task<TResultDto> GetByIdAsync<TResultDto>(
         TEntityId entityId,
         Expression<Func<TEntity, TResultDto>> projection,

--- a/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRORepositoryExtensions.cs
+++ b/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRORepositoryExtensions.cs
@@ -4,13 +4,29 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using OneBeyond.Studio.Application.SharedKernel.Repositories.Exceptions;
 using OneBeyond.Studio.Domain.SharedKernel.Entities;
 using OneBeyond.Studio.Domain.SharedKernel.Specifications;
 
 namespace OneBeyond.Studio.Application.SharedKernel.Repositories;
 
+/// <summary>
+/// Convenience overloads for <see cref="IRORepository{TEntity, TEntityId}"/>.
+/// </summary>
 public static class IRORepositoryExtensions
 {
+    /// <summary>
+    /// Returns the entity identified by <paramref name="entityId"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Type of the queried entity.</typeparam>
+    /// <typeparam name="TEntityId">Type of the entity identifier.</typeparam>
+    /// <param name="roRepository">Repository to query.</param>
+    /// <param name="entityId">Identifier of the entity to load.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The matching entity; never <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="roRepository"/> is <see langword="null"/>.</exception>
+    /// <exception cref="EntityNotFoundException">No entity with <paramref name="entityId"/> exists.</exception>
+    /// <exception cref="EntityAccessDeniedException">The entity exists but the active read policy denies access to it.</exception>
     public static Task<TEntity> GetByIdAsync<TEntity, TEntityId>(
         this IRORepository<TEntity, TEntityId> roRepository,
         TEntityId entityId,
@@ -26,6 +42,19 @@ public static class IRORepositoryExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Projects every entity onto <typeparamref name="TResultDto"/> and returns those matching
+    /// <paramref name="filter"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Type of the queried entity.</typeparam>
+    /// <typeparam name="TEntityId">Type of the entity identifier.</typeparam>
+    /// <typeparam name="TResultDto">Type each entity is projected onto.</typeparam>
+    /// <param name="roRepository">Repository to query.</param>
+    /// <param name="filter">Predicate applied to projected results, or <see langword="null"/> to match all.</param>
+    /// <param name="paging">Slice of the result set to return, or <see langword="null"/> for all matches.</param>
+    /// <param name="sortings">Ordering to apply.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="roRepository"/> is <see langword="null"/>.</exception>
     public static Task<IReadOnlyCollection<TResultDto>> ListAsync<TEntity, TEntityId, TResultDto>(
         this IRORepository<TEntity, TEntityId> roRepository,
         Expression<Func<TResultDto, bool>>? filter = default,
@@ -45,6 +74,16 @@ public static class IRORepositoryExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Counts the entities whose <typeparamref name="TResultDto"/> projection matches <paramref name="filter"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Type of the queried entity.</typeparam>
+    /// <typeparam name="TEntityId">Type of the entity identifier.</typeparam>
+    /// <typeparam name="TResultDto">Type each entity is projected onto.</typeparam>
+    /// <param name="roRepository">Repository to query.</param>
+    /// <param name="filter">Predicate applied to projected results, or <see langword="null"/> to count all.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="roRepository"/> is <see langword="null"/>.</exception>
     public static Task<int> CountAsync<TEntity, TEntityId, TResultDto>(
         this IRORepository<TEntity, TEntityId> roRepository,
         Expression<Func<TResultDto, bool>>? filter = default,
@@ -60,6 +99,17 @@ public static class IRORepositoryExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Determines whether any entity has a <typeparamref name="TResultDto"/> projection matching
+    /// <paramref name="filter"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Type of the queried entity.</typeparam>
+    /// <typeparam name="TEntityId">Type of the entity identifier.</typeparam>
+    /// <typeparam name="TResultDto">Type each entity is projected onto.</typeparam>
+    /// <param name="roRepository">Repository to query.</param>
+    /// <param name="filter">Predicate applied to projected results, or <see langword="null"/> to match all.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="roRepository"/> is <see langword="null"/>.</exception>
     public static Task<bool> AnyAsync<TEntity, TEntityId, TResultDto>(
         this IRORepository<TEntity, TEntityId> roRepository,
         Expression<Func<TResultDto, bool>>? filter = default,

--- a/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRWRepository.cs
+++ b/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRWRepository.cs
@@ -2,40 +2,99 @@ using System;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using OneBeyond.Studio.Application.SharedKernel.Repositories.Exceptions;
 using OneBeyond.Studio.Application.SharedKernel.Specifications;
 using OneBeyond.Studio.Domain.SharedKernel.Entities;
 
 namespace OneBeyond.Studio.Application.SharedKernel.Repositories;
 
 /// <summary>
-/// Represents a repository with read-write operations.
+/// Read-write repository over an aggregate root keyed by <typeparamref name="TAggregateRootId"/>.
+/// Returned aggregates are tracked, so changes to them are observed by the next write operation.
 /// </summary>
+/// <remarks>
+/// Each write operation persists its change to the underlying store before the returned task
+/// completes; there is no separate "save" step to call.
+/// </remarks>
+/// <typeparam name="TAggregateRoot">Type of the aggregate root.</typeparam>
+/// <typeparam name="TAggregateRootId">Type of the aggregate root identifier.</typeparam>
 public interface IRWRepository<TAggregateRoot, TAggregateRootId>
     where TAggregateRoot : AggregateRoot<TAggregateRootId>
     where TAggregateRootId : notnull
 {
+    /// <summary>
+    /// Returns the tracked aggregate root identified by <paramref name="aggregateRootId"/>.
+    /// </summary>
+    /// <param name="aggregateRootId">Identifier of the aggregate root to load.</param>
+    /// <param name="includes">Related object graph to load alongside the aggregate, or <see langword="null"/> for none.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The matching aggregate root; never <see langword="null"/>.</returns>
+    /// <exception cref="EntityNotFoundException">No aggregate root with <paramref name="aggregateRootId"/> exists.</exception>
+    /// <exception cref="EntityAccessDeniedException">The aggregate exists but the active read policy denies access to it.</exception>
     Task<TAggregateRoot> GetByIdAsync(
         TAggregateRootId aggregateRootId,
         Includes<TAggregateRoot>? includes,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns the single tracked aggregate root matching <paramref name="filter"/>.
+    /// </summary>
+    /// <param name="filter">Predicate that must identify at most one aggregate root.</param>
+    /// <param name="includes">Related object graph to load alongside the aggregate, or <see langword="null"/> for none.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The matching aggregate root; never <see langword="null"/>.</returns>
+    /// <exception cref="EntityNotFoundException">No aggregate root matches <paramref name="filter"/>.</exception>
+    /// <exception cref="EntityAccessDeniedException">A match exists but the active read policy denies access to it.</exception>
+    /// <exception cref="InvalidOperationException">More than one aggregate root matches <paramref name="filter"/>.</exception>
     Task<TAggregateRoot> GetByFilterAsync(
         Expression<Func<TAggregateRoot, bool>> filter,
         Includes<TAggregateRoot>? includes,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Adds <paramref name="aggregateRoot"/> and persists it to the underlying store.
+    /// </summary>
+    /// <param name="aggregateRoot">Aggregate root to add.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="aggregateRoot"/> is <see langword="null"/>.</exception>
+    /// <exception cref="EntityAccessDeniedException">The active create policy denies adding this aggregate.</exception>
     Task CreateAsync(
         TAggregateRoot aggregateRoot,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Persists changes to <paramref name="aggregateRoot"/> to the underlying store.
+    /// </summary>
+    /// <param name="aggregateRoot">Aggregate root whose changes are to be saved.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="aggregateRoot"/> is <see langword="null"/>.</exception>
+    /// <exception cref="EntityAccessDeniedException">The active update policy denies updating this aggregate.</exception>
     Task UpdateAsync(
         TAggregateRoot aggregateRoot,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Removes <paramref name="aggregateRoot"/> and persists the deletion to the underlying store.
+    /// </summary>
+    /// <param name="aggregateRoot">Aggregate root to delete.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="aggregateRoot"/> is <see langword="null"/>.</exception>
+    /// <exception cref="EntityAccessDeniedException">The active delete policy denies deleting this aggregate.</exception>
     Task DeleteAsync(
         TAggregateRoot aggregateRoot,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Deletes the aggregate root identified by <paramref name="id"/> directly in the underlying store,
+    /// or does nothing when no such aggregate exists.
+    /// </summary>
+    /// <remarks>
+    /// This overload deletes by key without loading or tracking the aggregate. It therefore bypasses the
+    /// delete access policy and the dispatch of any queued domain events. Use
+    /// <see cref="DeleteAsync(TAggregateRoot, CancellationToken)"/> when either is required.
+    /// </remarks>
+    /// <param name="id">Identifier of the aggregate root to delete.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task DeleteAsync(
         TAggregateRootId id,
         CancellationToken cancellationToken);

--- a/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRWRepositoryExtensions.cs
+++ b/src/OneBeyond.Studio.Application.SharedKernel/Repositories/IRWRepositoryExtensions.cs
@@ -3,12 +3,28 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using OneBeyond.Studio.Application.SharedKernel.Repositories.Exceptions;
 using OneBeyond.Studio.Domain.SharedKernel.Entities;
 
 namespace OneBeyond.Studio.Application.SharedKernel.Repositories;
 
+/// <summary>
+/// Convenience overloads for <see cref="IRWRepository{TAggregateRoot, TAggregateRootId}"/>.
+/// </summary>
 public static class IRWRepositoryExtensions
 {
+    /// <summary>
+    /// Returns the tracked aggregate root identified by <paramref name="aggregateRootId"/>.
+    /// </summary>
+    /// <typeparam name="TAggregateRoot">Type of the aggregate root.</typeparam>
+    /// <typeparam name="TAggregateRootId">Type of the aggregate root identifier.</typeparam>
+    /// <param name="rwRepository">Repository to query.</param>
+    /// <param name="aggregateRootId">Identifier of the aggregate root to load.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The matching aggregate root; never <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rwRepository"/> is <see langword="null"/>.</exception>
+    /// <exception cref="EntityNotFoundException">No aggregate root with <paramref name="aggregateRootId"/> exists.</exception>
+    /// <exception cref="EntityAccessDeniedException">The aggregate exists but the active read policy denies access to it.</exception>
     public static Task<TAggregateRoot> GetByIdAsync<TAggregateRoot, TAggregateRootId>(
         this IRWRepository<TAggregateRoot, TAggregateRootId> rwRepository,
         TAggregateRootId aggregateRootId,
@@ -24,6 +40,19 @@ public static class IRWRepositoryExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Returns the single tracked aggregate root matching <paramref name="filter"/>.
+    /// </summary>
+    /// <typeparam name="TAggregateRoot">Type of the aggregate root.</typeparam>
+    /// <typeparam name="TAggregateRootId">Type of the aggregate root identifier.</typeparam>
+    /// <param name="rwRepository">Repository to query.</param>
+    /// <param name="filter">Predicate that must identify at most one aggregate root.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The matching aggregate root; never <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rwRepository"/> is <see langword="null"/>.</exception>
+    /// <exception cref="EntityNotFoundException">No aggregate root matches <paramref name="filter"/>.</exception>
+    /// <exception cref="EntityAccessDeniedException">A match exists but the active read policy denies access to it.</exception>
+    /// <exception cref="InvalidOperationException">More than one aggregate root matches <paramref name="filter"/>.</exception>
     public static Task<TAggregateRoot> GetByFilterAsync<TAggregateRoot, TAggregateRootId>(
         this IRWRepository<TAggregateRoot, TAggregateRootId> rwRepository,
         Expression<Func<TAggregateRoot, bool>> filter,

--- a/src/OneBeyond.Studio.DataAccess.EFCore/Repositories/BaseRORepository.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/Repositories/BaseRORepository.cs
@@ -51,6 +51,7 @@ public class BaseRORepository<TDbContext, TEntity> : IRORepository<TEntity>
     protected AsyncLazy<DataAccessPolicy<TEntity>?> ReadDataAccessPolicy { get; }
     protected IEntityTypeProjections<TEntity> EntityTypeProjections { get; }
 
+    /// <inheritdoc/>
     public async Task<IReadOnlyCollection<TEntity>> ListAsync(
         Expression<Func<TEntity, bool>>? filter = null,
         Includes<TEntity>? includes = null,
@@ -63,6 +64,7 @@ public class BaseRORepository<TDbContext, TEntity> : IRORepository<TEntity>
         return await query.ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<IReadOnlyCollection<TResultDto>> ListAsync<TResultDto>(
         Expression<Func<TEntity, bool>>? preFilter,
         Expression<Func<TResultDto, bool>>? filter = null,
@@ -76,6 +78,7 @@ public class BaseRORepository<TDbContext, TEntity> : IRORepository<TEntity>
         return await resultQuery.ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<IReadOnlyCollection<TResultDto>> ListAsync<TResultDto>(
         Expression<Func<TEntity, TResultDto>> projection,
         Expression<Func<TEntity, bool>>? filter = null,
@@ -90,6 +93,7 @@ public class BaseRORepository<TDbContext, TEntity> : IRORepository<TEntity>
         return await resultQuery.ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<int> CountAsync(
         Expression<Func<TEntity, bool>>? filter = null,
         CancellationToken cancellationToken = default)
@@ -99,6 +103,7 @@ public class BaseRORepository<TDbContext, TEntity> : IRORepository<TEntity>
         return await query.CountAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<int> CountAsync<TResultDto>(
         Expression<Func<TEntity, bool>>? preFilter,
         Expression<Func<TResultDto, bool>>? filter = null,
@@ -110,6 +115,7 @@ public class BaseRORepository<TDbContext, TEntity> : IRORepository<TEntity>
         return await resultQuery.CountAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<bool> AnyAsync(
         Expression<Func<TEntity, bool>>? filter = null,
         CancellationToken cancellationToken = default)
@@ -119,6 +125,7 @@ public class BaseRORepository<TDbContext, TEntity> : IRORepository<TEntity>
         return await query.AnyAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task<bool> AnyAsync<TResultDto>(
         Expression<Func<TEntity, bool>>? preFilter,
         Expression<Func<TResultDto, bool>>? filter = null,
@@ -245,6 +252,7 @@ public class BaseRORepository<TDbContext, TEntity, TEntityId>
     {
     }
 
+    /// <inheritdoc/>
     public async Task<TEntity> GetByIdAsync(
         TEntityId entityId,
         Includes<TEntity>? includes,
@@ -262,6 +270,7 @@ public class BaseRORepository<TDbContext, TEntity, TEntityId>
         return entity!;
     }
 
+    /// <inheritdoc/>
     public async Task<TResultDto> GetByIdAsync<TResultDto>(
         TEntityId entityId,
         CancellationToken cancellationToken)
@@ -282,6 +291,7 @@ public class BaseRORepository<TDbContext, TEntity, TEntityId>
         return entityDto!;
     }
 
+    /// <inheritdoc/>
     public async Task<TResultDto> GetByIdAsync<TResultDto>(
         TEntityId entityId,
         Expression<Func<TEntity, TResultDto>> projection,

--- a/src/OneBeyond.Studio.DataAccess.EFCore/Repositories/BaseRWRepository.cs
+++ b/src/OneBeyond.Studio.DataAccess.EFCore/Repositories/BaseRWRepository.cs
@@ -18,11 +18,12 @@ namespace OneBeyond.Studio.DataAccess.EFCore.Repositories;
 
 /// <summary>
 /// Implements base read-write repository for the <typeparamref name="TAggregateRoot"/> type using EF Core.
-/// All the entities returned by this repository are trackable.
+/// All the entities returned by this repository are trackable, and each write persists immediately via
+/// <see cref="SaveChangesAsync(CancellationToken)"/>.
 /// </summary>
-/// <typeparam name="TDbContext"></typeparam>
-/// <typeparam name="TAggregateRoot"></typeparam>
-/// <typeparam name="TAggregateRootId"></typeparam>
+/// <typeparam name="TDbContext">DB context type.</typeparam>
+/// <typeparam name="TAggregateRoot">Aggregate root type.</typeparam>
+/// <typeparam name="TAggregateRootId">Aggregate root identifier type.</typeparam>
 public class BaseRWRepository<TDbContext, TAggregateRoot, TAggregateRootId>
     : BaseRORepository<TDbContext, TAggregateRoot, TAggregateRootId>
     , IRWRepository<TAggregateRoot, TAggregateRootId>
@@ -63,6 +64,7 @@ public class BaseRWRepository<TDbContext, TAggregateRoot, TAggregateRootId>
     protected AsyncLazy<Action<TAggregateRoot>> EnsureUpdateDataAccessPolicy { get; }
     protected AsyncLazy<Action<TAggregateRoot>> EnsureDeleteDataAccessPolicy { get; }
 
+    /// <inheritdoc cref="IRWRepository{TAggregateRoot, TAggregateRootId}.GetByIdAsync"/>
     public new async Task<TAggregateRoot> GetByIdAsync(
         TAggregateRootId aggregateRootId,
         Includes<TAggregateRoot>? includes,
@@ -82,6 +84,7 @@ public class BaseRWRepository<TDbContext, TAggregateRoot, TAggregateRootId>
         return entity!;
     }
 
+    /// <inheritdoc/>
     public async Task<TAggregateRoot> GetByFilterAsync(
         Expression<Func<TAggregateRoot, bool>> filter,
         Includes<TAggregateRoot>? includes,
@@ -96,6 +99,7 @@ public class BaseRWRepository<TDbContext, TAggregateRoot, TAggregateRootId>
         return entity!;
     }
 
+    /// <inheritdoc/>
     public async Task CreateAsync(TAggregateRoot aggregateRoot, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(aggregateRoot, nameof(aggregateRoot));
@@ -105,6 +109,7 @@ public class BaseRWRepository<TDbContext, TAggregateRoot, TAggregateRootId>
         await SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task UpdateAsync(TAggregateRoot aggregateRoot, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(aggregateRoot, nameof(aggregateRoot));
@@ -114,6 +119,7 @@ public class BaseRWRepository<TDbContext, TAggregateRoot, TAggregateRootId>
         await SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public async Task DeleteAsync(TAggregateRoot aggregateRoot, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(aggregateRoot, nameof(aggregateRoot));
@@ -123,6 +129,7 @@ public class BaseRWRepository<TDbContext, TAggregateRoot, TAggregateRootId>
         await SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
     public Task DeleteAsync(TAggregateRootId id, CancellationToken cancellationToken)
     {
         var aggregate = DbSet.Value.Find(id);


### PR DESCRIPTION
LLMs burn unnecessary tokens per-session trying to understand these types. Document the functionality, guarantees and exceptions to avoid this.